### PR TITLE
Prevent genometools Assertion Error when calling remove_leaf

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -23,4 +23,4 @@ jobs:
           apt-get -y install openjdk-11-jre-headless; apt-get clean
           curl -fsSL get.nextflow.io | bash
       - name: Run pipeline
-        run: ./nextflow -c loc_github.config -c params_default.config run annot.nf -ansi-log false --do_circos=false --run_braker=false
+        run: NXF_VER=22.10.0 ./nextflow -c loc_github.config -c params_default.config run annot.nf -ansi-log false --do_circos=false --run_braker=false

--- a/bin/split_genes_at_gaps.lua
+++ b/bin/split_genes_at_gaps.lua
@@ -91,6 +91,10 @@ function stream:process_current_cluster()
         local rest = clone_cc(cur_gene)
         for c in cur_gene:children() do
           if c:get_range():get_start() > g:get_range():get_end() then
+            -- ensure c is a leaf by removing any children
+            for cc in c:direct_children() do
+              c:remove_leaf(cc)
+            end
             cur_gene:remove_leaf(c)
           elseif c:get_range():overlap(g:get_range()) then
             if c:get_range():get_start() > g:get_range():get_start() - 1 then
@@ -113,6 +117,10 @@ function stream:process_current_cluster()
         end
         for c in rest:children() do
           if c:get_range():get_end() < g:get_range():get_start() then
+            -- ensure c is a leaf by removing any children
+            for cc in c:direct_children() do
+              c:remove_leaf(cc)
+            end
             rest:remove_leaf(c)
           elseif c:get_range():overlap(g:get_range()) then
             -- XXX make sure we don't create invalid genes


### PR DESCRIPTION
An on-going problem which affected the generation of circos plots was traced back to an assertion error being raised during split_splice_models_at_gaps process, specifically at https://github.com/iii-companion/companion/blob/master/bin/split_genes_at_gaps.lua#L94. I dealt with this by allowing the circos processes to fail silently so as not to derail the entire pipeline - a "sticking plaster" approach.

It has recently become apparent that the same assertion errors might be causing greatly reduced annotations in the final GFF3 output. Compare https://companion.gla.ac.uk/jobs/6d34bf395da0e4840e772c6e and https://companion.gla.ac.uk/jobs/1de42786d7fdd57ff6951caa, which have similar assemblies and same parametrisation but vastly different number of genes in output.

I opened a genometools [ticket ](https://github.com/genometools/genometools/issues/1020)to enquire whether the Assertion error was indeed a bug, and a [PR](https://github.com/genometools/genometools/pull/1021) is currently active which will ensure that a Lua runtime error is thrown instead of the Assertion error from C. 

The reason that the Assertion error is being triggered on the Companion side is because the call to remove_leaf is sometimes being made to a feature node that isn't a leaf (i.e. an mRNA feature which has child CDS features). This simple fix to Companion will ensure that any such children are first removed before the mRNA feature is subsequently removed, and so the split_genes_at_gaps.lua will not halt execution early as it was previously doing.