### PR TITLE
Fix distribution gff errors

### DIFF
--- a/bin/split_genes_at_gaps.lua
+++ b/bin/split_genes_at_gaps.lua
@@ -95,6 +95,10 @@ function stream:process_current_cluster()
         local rest = clone_cc(cur_gene)
         for c in cur_gene:children() do
           if c:get_range():get_start() > g:get_range():get_end() then
+            -- ensure c is a leaf by removing any children
+            for cc in c:direct_children() do
+              pcall(remove_leaf, c, cc)
+            end
             pcall(remove_leaf, cur_gene, c)
           elseif c:get_range():overlap(g:get_range()) then
             if c:get_range():get_start() > g:get_range():get_start() - 1 then
@@ -117,6 +121,10 @@ function stream:process_current_cluster()
         end
         for c in rest:children() do
           if c:get_range():get_end() < g:get_range():get_start() then
+            -- ensure c is a leaf by removing any children
+            for cc in c:direct_children() do
+              pcall(remove_leaf, c, cc)
+            end
             pcall(remove_leaf, rest, c)
           elseif c:get_range():overlap(g:get_range()) then
             -- XXX make sure we don't create invalid genes


### PR DESCRIPTION
reinstate iterating through all exons to remove leaves with pcall remove_leaf

I believe this was the cause of an error further downstream where jobs were failing during make_distribution_gff process. Genes were being incorrectly split in split_splice_models_at_gaps, which meant that child features were not contained in the range of the parent gene.